### PR TITLE
Update associacao-brasileira-de-normas-tecnicas.csl

### DIFF
--- a/associacao-brasileira-de-normas-tecnicas.csl
+++ b/associacao-brasileira-de-normas-tecnicas.csl
@@ -1,644 +1,612 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" demote-non-dropping-particle="never" default-locale="pt-BR">
-  <!--Em caso de sobrenome composto, este nao sera desmontado para a montagem da citacao ou bibliografia como no caso de L. Van Der Pijl-->
-  <info>
-    <title>Associação Brasileira de Normas Técnicas (Portuguese - Brazil)</title>
-    <title-short>ABNT</title-short>
-    <id>http://www.zotero.org/styles/associacao-brasileira-de-normas-tecnicas</id>
-    <link href="http://www.zotero.org/styles/associacao-brasileira-de-normas-tecnicas" rel="self"/>
-    <link href="https://forums.zotero.org/discussion/22148/how-to-apply-disambiguation-in-citation-just-when-works-of-different-authors-are-in-the-same-year/?Focus=147094#Comment_147094" rel="documentation"/>
-    <author>
-      <name>Juliana Geyna Régis</name>
-      <email>juliana.regis@ipea.gov.br</email>
-    </author>
-    <contributor>
-      <name>Lucas Mation</name>
-      <email>lucas.mation@ipea.gov.br</email>
-    </contributor>
-    <contributor>
-      <name>Eduardo Michelotti Bettoni</name>
-      <email>webtur@ufpr.br</email>
-    </contributor>
-    <contributor>
-      <name>Paulo Augusto Nascimento</name>
-      <email>paulo.nascimento@ipea.gov.br</email>
-    </contributor>
-    <contributor>
-      <name>Iuri Gavronski</name>
-      <email>iuri at ufrgs dot br</email>
-    </contributor>
-    <contributor>
-      <name>José Antonio Meira da Rocha</name>
-      <email>joseantoniorocha@gmail.com</email>
-      <uri>http://meiradarocha.jor.br</uri>
-    </contributor>
-    <contributor>
-      <name>Mario José</name>
-      <email>gnumario [at-mark] gmail [dot-mark] com</email>
-    </contributor>
-    <category citation-format="author-date"/>
-    <category field="generic-base"/>
-    <summary>The Brazilian Standard Style in accordance with ABNT-NBR 10520.2002 and ABNT-NBR 6023.2002</summary>
-    <updated>2013-05-01T03:53:13+00:00</updated>
-    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-  </info>
-  <locale xml:lang="pt-BR">
-    <terms>
-      <!--Abreviacoes meses "Forma Curta"-->
-      <term name="month-01" form="short">jan.</term>
-      <term name="month-02" form="short">fev.</term>
-      <term name="month-03" form="short">mar.</term>
-      <term name="month-04" form="short">abr.</term>
-      <term name="month-05" form="short">maio</term>
-      <term name="month-06" form="short">jun.</term>
-      <term name="month-07" form="short">jul.</term>
-      <term name="month-08" form="short">ago.</term>
-      <term name="month-09" form="short">set.</term>
-      <term name="month-10" form="short">out.</term>
-      <term name="month-11" form="short">nov.</term>
-      <term name="month-12" form="short">dez.</term>
-      <!--Os termos abaixo serao utilizados quando houverem nomes de editores. Apos a citacao dos nomes, eles irao aparecer entre parenteses.-->
-      <term name="editor" form="short">
-        <single>ed</single>
-        <multiple>eds</multiple>
-      </term>
-      <term name="container-author" form="short">
-        <single>ed</single>
-        <multiple>eds</multiple>
-      </term>
-      <term name="collection-editor" form="short">
-        <single>ed</single>
-        <multiple>eds</multiple>
-      </term>
-    </terms>
-  </locale>
-  <!--A macro 'container-contribuitor' e responsavel por mostrar os nomes dos editores, serao apresentados SOBRENOME, INICIAIS PRENOMES 
-tendo as inicias separadas por ponto.-->
-  <macro name="container-contributors">
-    <choose>
-      <if type="chapter">
-        <names variable="container-author" delimiter=", ">
-          <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; " delimiter-precedes-last="always">
-            <name-part name="family" text-case="uppercase"/>
-            <name-part name="given" text-case="uppercase"/>
-          </name>
-          <label form="short" prefix=" (" suffix=".). " text-case="capitalize-first"/>
-          <substitute>
-            <names variable="editor"/>
-            <names variable="collection-editor"/>
-          </substitute>
-        </names>
-      </if>
-    </choose>
-  </macro>
-  <!--A macro 'secundary-contribuitor' e responsavel por mostrar os nomes dos organizadores, serao apresentados SOBRENOME, INICIAIS PRENOMES
-tendo as inicias separadas por ponto.-->
-  <macro name="secondary-contributors">
-    <choose>
-      <if type="chapter" match="none">
-        <names variable="editor" delimiter="; " prefix=" (" suffix=")">
-          <name initialize-with=". " delimiter=", "/>
-          <label form="short" prefix=", " text-case="capitalize-first" suffix="."/>
-        </names>
-      </if>
-    </choose>
-  </macro>
-  <!--A macro 'translator' e responsavel por mostrar os nomes dos tradutores, serao apresentados SOBRENOME, INICIAIS PRENOMES
+	<!--Em caso de sobrenome composto, este não será desmontado para a montagem da citação ou bibliografia como no caso de L. Van Der Pijl-->
+	<info>
+		<title>Associação Brasileira de Normas Técnicas (ABNT)</title>
+		<id>http://www.zotero.org/styles/associacao-brasileira-de-normas-tecnicas</id>
+		<link href="http://www.zotero.org/styles/associacao-brasileira-de-normas-tecnicas" rel="self"/>
+		<author>
+			<name>Juliana Geyna Régis</name>
+			<email>juliana.regis@ipea.gov.br</email>
+		</author>
+		<contributor>
+			<name>Lucas Mation</name>
+			<email>lucas.mation@ipea.gov.br</email>
+		</contributor>
+		<contributor>
+			<name>Paulo Augusto Nascimento</name>
+			<email>paulo.nascimento@ipea.gov.br</email>
+		</contributor>
+		<contributor>
+			<name>Iuri Gavronski</name>
+			<email>iuri at ufrgs dot br</email>
+		</contributor>
+		<contributor>
+			<name>Eduardo Bettoni</name>
+			<email>webtur @ ufpr dot br</email>
+		</contributor>
+		<contributor>
+			<name>José Antonio Meira da Rocha</name>
+			<email>joseantoniorocha@gmail.com</email>
+			<uri>http://meiradarocha.jor.br</uri>
+		</contributor>
+		<contributor>
+			<name>Mario José</name>
+			<email>gnumario [at-mark] gmail [dot-mark] com</email>
+		</contributor>
+		<contributor>
+			<name>Hildo Guillardi Júnior</name>
+			<email>hildogjr@github</email>
+			<!-- Modificado em 22/07/2012
+			Corrigido erros de pontuação (sufixo) nos títulos, nomes de sites e datas nas referências.
+			A expressão "et al." deve ficar em itálico por ser em outra língua.
+			O espaçamento entre cada entrada de referências deve ser de 1 linha ("12 pt" usando as letras padrões).
+			O mês "maio" não é seguido de sufixo ".".
+			Quando usada a expressão "Anais..." (que aparece em negrito), o título não permanece em negrito.
+			Nas referências devem aparecer todos os autores, sem limite de quantidade.
+			Quando mais de uma citação em uma única vez, devem ser separadas por ";".
+			Quando as citações de mesmo autor puderem ser diferenciadas apenas pelo ano, colapsar os nomes.
+			Modificado em 09/04/2023 para publicação.
+			-->
+		</contributor>
+		<category citation-format="author-date"/>
+		<category field="generic-base"/>
+		<updated>2023-04-09T03:46:02+00:00</updated>
+		<summary>The Brazilian standard style</summary>
+		<rights>This work is licensed under a Creative Commons Attribution-SháreAlike 3.0 License: http://creativecommons.org/licenses/by-sa/3.0/</rights>
+	</info>
+	<locale xml:lang="pt-BR">
+	<terms>
+		<!--Abreviações meses "Forma Curta"-->
+		<term name="month-01" form="short">jan.</term>
+		<term name="month-02" form="short">fev.</term>
+		<term name="month-03" form="short">mar.</term>
+		<term name="month-04" form="short">abr.</term>
+		<term name="month-05" form="short">maio</term>
+		<term name="month-06" form="short">jun.</term>
+		<term name="month-07" form="short">jul.</term>
+		<term name="month-08" form="short">ago.</term>
+		<term name="month-09" form="short">set.</term>
+		<term name="month-10" form="short">out.</term>
+		<term name="month-11" form="short">nov.</term>
+		<term name="month-12" form="short">dez.</term>
+		<!--Os termos abaixo serão utilizados quando houverem nomes de editores. Após a citação dos nomes, eles irão aparecer entre parenteses.-->
+		<term name="editor" form="short">
+			<single>ed</single>
+			<multiple>eds</multiple>
+		</term>
+		<term name="container-author" form="short">
+			<single>ed</single>
+			<multiple>eds</multiple>
+		</term>
+		<term name="collection-editor" form="short">
+			<single>ed</single>
+			<multiple>eds</multiple>
+		</term>
+	</terms>
+	</locale>
+	<!--A macro 'container-contribuitor' é responsável por mostrar os nomes dos editores, serão apresentados SOBRENOME, INICIAIS PRENOMES tendo as inicias separadas por ponto.-->
+	<macro name="container-contributors">
+		<choose>
+		<if type="chapter">
+			<names variable="container-author" delimiter=", ">
+				<name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; " delimiter-precedes-last="always">
+					<name-part name="family" text-case="uppercase"/>
+					<name-part name="given" text-case="uppercase"/>
+				</name>
+				<et-al/>
+				<label form="short" prefix="(" suffix=".). " text-case="capitalize-first"/>
+				<substitute>
+					<names variable="editor"/>
+					<names variable="collection-editor"/>
+				</substitute>
+			</names>
+		</if>
+		</choose>
+	</macro>
+	<!--A macro 'secundary-contribuitor' é responsável por mostrar os nomes dos organizadores, serão apresentados SOBRENOME, INICIAIS PRENOMES tendo as inicias separadas por ponto.-->
+	<macro name="secondary-contributors">
+		<choose>
+		<if type="chapter" match="none">
+		<names variable="editor" delimiter=", " prefix="(" suffix=")">
+			<name and="symbol" initialize-with=". " delimiter=", "/>
+			<label form="short" prefix=", " text-case="capitalize-first" suffix="."/>
+		</names>
+		</if>
+		</choose>
+	</macro>
+	<!--A macro 'translator' é responsável por mostrar os nomes dos tradutores, serão apresentados SOBRENOME, INICIAIS PRENOMES
 tendo as inicias separadas por ponto. -->
-  <macro name="translator">
-    <text value="Traducao "/>
-    <names variable="translator" delimiter="; ">
-      <name delimiter="; " sort-separator=" " delimiter-precedes-last="always">
-        <name-part name="given" text-case="capitalize-first"/>
-        <name-part name="family" text-case="capitalize-first"/>
-      </name>
-    </names>
-  </macro>
-  <!--A macro 'author' e responsavel por mostrar os nomes dos autores na bibliografia, serao no formato SOBRENOME, INICIAIS PRENOMES, tendo 
-as inicias separadas por ponto. Quando houver mais de tres autores, somente o primeiro sera mostrado e no lugar dos outros
-aparecera a expess o 'et. al.'. Na regra da ABNT essa expressao deve aparecer em fonte normal-->
-  <macro name="author">
-    <names variable="author">
-      <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; " delimiter-precedes-last="always">
-        <name-part name="family" text-case="uppercase"/>
-        <name-part name="given" text-case="uppercase"/>
-      </name>
-      <label form="short" prefix=" (" suffix=".)" text-case="uppercase"/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
-        <text macro="title"/>
-      </substitute>
-    </names>
-  </macro>
-  <!--A macro 'author-short' e responsavel por mostrar os nomes dos autores na citacao (no meio do texto). Nela aparecera apenas o ultimo nome
-do autor. Na regra da ABNT o sobrenome deve aparecer com todas as letras em caixa alta-->
-  <macro name="author-short">
-    <names variable="author">
-      <name form="short" name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; " delimiter-precedes-last="never">
-        <name-part name="family" text-case="uppercase"/>
-        <name-part name="given" text-case="uppercase"/>
-      </name>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
-        <choose>
-          <if type="book">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
-      </substitute>
-    </names>
-  </macro>
-  <!--A macro 'access' e utilizada em arquivos de paginas da web. Ela e responsavel por mostrar a URL do site pesquisado e a data do acesso-->
-  <macro name="access">
-    <text variable="URL" prefix="Disponível em: &lt;" suffix="&gt;"/>
-    <date variable="accessed" prefix=". Acesso em: ">
-      <date-part name="day" suffix=" "/>
-      <date-part name="month" form="short" suffix=". " text-case="lowercase"/>
-      <date-part name="year"/>
-    </date>
-  </macro>
-  <!--A macro 'title' e responsavel por mostrar o titulo principal do arquivo. Em todos os tipos ele aparecera em negrito logo apos os nomes dos
-autores, exceto em arquivos do tipo 'artigo de jornal, artigo de revista, artigo de periodico', nesses arquivos eles irao aparecer em fonte normal.-->
-  <macro name="title">
-    <choose>
-      <if type="chapter bill" match="any">
-        <text variable="title"/>
-      </if>
-      <else-if type="book thesis" match="any">
-        <text variable="title" font-weight="bold"/>
-      </else-if>
-      <else-if type="article-newspaper article-magazine article-journal" match="any">
-        <text variable="title"/>
-      </else-if>
-      <else>
-        <text variable="title" font-weight="bold"/>
-      </else>
-    </choose>
-  </macro>
-  <!-- Titulo dos Anais-->
-  <macro name="container-title">
-    <choose>
-      <if type="paper-conference" match="any">
-        <text variable="container-title" suffix=". "/>
-        <text value="Anais" font-weight="bold"/>
-        <text value="..."/>
-      </if>
-      <else>
-        <text variable="container-title" font-weight="bold"/>
-      </else>
-    </choose>
-  </macro>
-  <!--A macro 'publisher' e responsavel por mostrar o nome da editora responsavel pela publicacao-->
-  <macro name="publisher">
-    <choose>
-      <if match="any" variable="publisher-place publisher">
-        <choose>
-          <if variable="publisher-place">
-            <text variable="publisher-place" suffix=": "/>
-          </if>
-          <else-if type="entry-encyclopedia">
-        </else-if>
-          <else>
-            <text value="[s.l.] "/>
-          </else>
-        </choose>
-        <choose>
-          <if variable="publisher">
-            <text variable="publisher" suffix=", "/>
-            <text macro="issued"/>
-          </if>
-          <else>
-            <text value="[s.n.]"/>
-          </else>
-        </choose>
-      </if>
-      <else>
-        <text value="[s.l: s.n.]"/>
-      </else>
-    </choose>
-  </macro>
-  <!--A macro 'event' sera utilizada em arquivos do tipo Evento/Conferencia. Ela e responsavel por mostrar o nome da conferencia, que tera formatacao
-em caixa alta. Utiliza-se antes do nome da conferencia a expressao "In". Segundo a regra da ABNT ela deve ser em fonte normal-->
-  <macro name="event">
-    <choose>
-      <if variable="event">
-        <choose>
-          <if variable="genre" match="none">
-            <text term="in" text-case="capitalize-first" suffix=": "/>
-            <text variable="event" text-case="uppercase"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <text variable="genre" text-case="capitalize-first"/>
-              <text term="presented at"/>
-              <text variable="event"/>
-            </group>
-          </else>
-        </choose>
-      </if>
-    </choose>
-  </macro>
-  <!--A macro 'issued' e utilizada quando devemos mostrar a data completa exemplo: 03 mar. 2011.-->
-  <macro name="issued">
-    <choose>
-      <if variable="issued" match="any">
-        <group>
-          <choose>
-            <if type="book chapter" match="none">
-              <date variable="issued">
-                <date-part name="day" suffix=" "/>
-                <date-part name="month" form="short" suffix=" "/>
-              </date>
-            </if>
-          </choose>
-          <date variable="issued">
-            <date-part name="year"/>
-          </date>
-        </group>
-      </if>
-      <else>
-        <text value="[s.d.]"/>
-      </else>
-    </choose>
-  </macro>
-  <!--A macro 'issued' e utilizada quando desejamos que apareca apenas o ano-->
-  <macro name="issued-year">
-    <choose>
-      <if variable="issued" match="any">
-        <date variable="issued">
-          <date-part name="year"/>
-        </date>
-      </if>
-      <else>
-        <text value="[s.d.]"/>
-      </else>
-    </choose>
-  </macro>
-  <!--A macro 'edition' e responsavel por mostrar o numero da edicao.-->
-  <macro name="edition">
-    <choose>
-      <!--Se for capitulo de livro aparecera somente o numero-->
-      <if type="book chapter" match="any">
-        <choose>
-          <if is-numeric="edition">
-            <group delimiter=" ">
-              <number variable="edition" form="numeric" suffix="."/>
-              <text term="edition" form="short" suffix="."/>
-            </group>
-          </if>
-          <else>
-            <!--Se for outro tipo de documento aparera o numero e depois a descricao "ed."-->
-            <text variable="edition" suffix=" ed."/>
-          </else>
-        </choose>
-      </if>
-    </choose>
-  </macro>
-  <!--A macro 'locators'tem como funcao mostrar os dados complementares do arquivo (paginas, secao, volume, etc)-->
-  <macro name="locators">
-    <choose>
-      <!--Se for projeto de lei mostrara o dia, mes "forma curta", ano, secao "Sec." e pagina "p."-->
-      <if type="bill">
-        <group prefix=". " delimiter=", ">
-          <date variable="issued">
-            <date-part name="day"/>
-            <date-part prefix=" " name="month" form="short"/>
-            <date-part prefix=" " name="year"/>
-          </date>
-          <text variable="section" prefix="Sec. "/>
-          <text variable="page" prefix="p. " suffix="."/>
-        </group>
-      </if>
-      <!--Se for artigos de jornal, revista, etc. Aparecera o volume "v.", edicao "n." e a pagina do artigo "p."-->
-      <else-if match="any" type="article-journal article-magazine article-newspaper">
-        <group delimiter=", ">
-          <group delimiter=", ">
-            <text variable="volume" prefix="v. "/>
-            <text variable="issue" prefix="n. "/>
-          </group>
-          <text variable="page" prefix="p. "/>
-        </group>
-      </else-if>
-      <!--Se for capitulo de livro aparecera o volume "v." e a pagina "p."-->
-      <else-if match="any" type="book chapter">
-        <group delimiter=", ">
-          <group>
-            <text variable="volume" prefix="v. "/>
-            <text variable="page" prefix="p. "/>
-          </group>
-        </group>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="collection-title">
-    <text variable="collection-title"/>
-    <text variable="collection-number" prefix=" "/>
-  </macro>
-  <macro name="genre">
-    <text variable="genre"/>
-  </macro>
-  <macro name="citation-locator">
-    <group>
-      <label variable="locator" form="short"/>
-      <text variable="locator" prefix=" "/>
-    </group>
-  </macro>
-  <macro name="place">
-    <choose>
-      <if match="any" variable="publisher-place">
-        <text variable="publisher-place"/>
-      </if>
-    </choose>
-  </macro>
-  <macro name="archive">
-    <group>
-      <text variable="archive" prefix=" "/>
-    </group>
-  </macro>
-  <!--Citacao-->
-  <!--et al. aparece a partir de 04 autores-->
-  <citation et-al-min="4" et-al-use-first="1" collapse="year" disambiguate-add-year-suffix="true">
-    <sort>
-      <key macro="author"/>
-      <!--Puxa o autor primeiro-->
-      <key variable="issued"/>
-      <!--Depois o ano-->
-    </sort>
-    <layout prefix="(" suffix=")" delimiter="; ">
-      <!--Entre parenteses separando os autores com ponto-e-virgula-->
-      <group>
-        <text suffix=", " macro="author-short"/>
-        <!--Seperando os autores das datas usando virgula-->
-        <text macro="issued-year"/>
-        <text prefix=", " macro="citation-locator"/>
-      </group>
-    </layout>
-  </citation>
-  <!--Bibliografia-->
-  <!--et al. aparece a partir de 04 autores-->
-  <bibliography hanging-indent="false" et-al-min="4" et-al-use-first="1" entry-spacing="1">
-    <sort>
-      <key macro="author"/>
-      <!--Puxa o autor primeiro-->
-      <key variable="issued"/>
-      <!--Depois o ano-->
-    </sort>
-    <layout>
-      <choose>
-        <!--Projeto de lei-->
-        <if type="bill">
-          <group>
-            <text macro="author" suffix=". "/>
-            <!--autor-->
-            <text variable="number" suffix=". "/>
-            <!--Numero da lei-->
-            <text macro="title" suffix=". "/>
-            <!--Titulo-->
-            <text variable="references" font-weight="bold"/>
-            <!--Historico em negrito-->
-            <text variable="note"/>
-            <!--Campo 'extra' caso queira colocar alguma observacao-->
-            <text macro="locators" suffix=". "/>
-            <!--Dados complementares "secao, pagina"-->
-          </group>
-        </if>
-        <!--Mapa-->
-        <else-if type="map">
-          <group>
-            <text macro="author" suffix=". "/>
-            <!--autor-->
-            <text macro="title" suffix=", "/>
-            <!--Titulo-->
-            <text macro="issued" suffix=". "/>
-            <!--data-->
-            <text variable="note" suffix=". "/>
-            <!--Campo 'extra' caso queira colocar alguma observacao-->
-          </group>
-        </else-if>
-        <!--Livro-->
-        <else-if type="book">
-          <group>
-            <text macro="author" suffix=". "/>
-            <!--autor-->
-            <text macro="title" suffix=". "/>
-            <!--Titulo-->
-            <text macro="translator" suffix=". "/>
-            <!--Traducao-->
-            <text macro="edition" suffix=". "/>
-            <!--Edicao-->
-            <text macro="publisher" suffix=". "/>
-            <!--Local, data, etc-->
-            <text macro="locators"/>
-            <!--Dados complementares "pagina, volume"-->
-          </group>
-        </else-if>
-        <!--Conferencia-->
-        <else-if type="chapter">
-          <group>
-            <text macro="author" suffix=". "/>
-            <!--autor-->
-            <text macro="title" suffix=". "/>
-            <!--Titulo-->
-            <text macro="secondary-contributors" suffix=". "/>
-            <text term="in" text-case="capitalize-first" suffix=": "/>
-            <!--In:-->
-            <text macro="container-contributors" suffix=". "/>
-            <!--Nomes de editores-->
-            <text macro="container-title" suffix=". "/>
-            <!--Titulo da conferencia-->
-            <text variable="collection-title" suffix=". "/>
-            <text macro="translator" suffix=". "/>
-            <!--Traducao-->
-            <text macro="edition" suffix=". "/>
-            <!--Edicao-->
-            <text macro="publisher" suffix=". "/>
-            <!--Local, data, etc-->
-            <text macro="locators" suffix=". "/>
-            <!--Dados complementares "pagina, volume"-->
-          </group>
-        </else-if>
-        <!--Artigo de revista, jornal, etc-->
-        <else-if type="article-newspaper article-magazine article-journal" match="any">
-          <group>
-            <text macro="author" suffix=". "/>
-            <!--Autor-->
-            <text macro="title" suffix=". "/>
-            <!--Titulo do artigo-->
-            <text macro="container-title" suffix=", "/>
-            <!--Titulo da publicacao-->
-            <text variable="collection-title" suffix=". "/>
-            <!--Titulo da serie-->
-            <text macro="edition" suffix=", "/>
-            <!--Edicao-->
-            <text macro="locators" suffix=", "/>
-            <!--Dados complementares "pagina, volume"-->
-            <text macro="issued" suffix=". "/>
-            <!--Data-->
-          </group>
-        </else-if>
-        <!--Tese-->
-        <else-if type="thesis">
-          <group>
-            <text macro="author" suffix=". "/>
-            <!--Autor-->
-            <text macro="title" suffix=". "/>
-            <!--Titulo-->
-            <text macro="genre" suffix="&#8212;"/>
-            <!--Tipo-->
-            <text macro="publisher" suffix="."/>
-            <!--Local, data, etc-->
-          </group>
-        </else-if>
-        <!-- Nao ha norma ABNT para manuscritos -->
-        <else-if type="manuscript">
-          <group>
-            <text macro="author" suffix=". "/>
-            <!--Autor-->
-            <text macro="title" suffix=". "/>
-            <!--Titulo-->
-            <text macro="edition" suffix=". "/>
-            <!--Edicao-->
-            <text macro="place" suffix=", "/>
-            <text macro="issued" suffix=". "/>
-            <!--Data-->
-            <text macro="access" suffix=". "/>
-            <!--URL, data do acesso-->
-            <text macro="archive" suffix=". "/>
-            <!--Arquive-->
-          </group>
-        </else-if>
-        <!--Pagina da WEB-->
-        <else-if type="webpage">
-          <group>
-            <text macro="author" suffix=". "/>
-            <!--Autor-->
-            <text macro="title" suffix=". "/>
-            <!--Titulo-->
-            <text macro="genre" suffix=". "/>
-            <text macro="access" suffix=". "/>
-            <!--URL, data do acesso-->
-          </group>
-        </else-if>
-        <!--Relatorio-->
-        <else-if type="report">
-          <group>
-            <text macro="author" suffix=". "/>
-            <!--Autor-->
-            <text macro="title"/>
-            <!--Titulo-->
-            <text macro="container-contributors"/>
-            <!--Nomes de editores-->
-            <text macro="secondary-contributors"/>
-            <text macro="container-title"/>
-            <!--Titulo da publicacao-->
-            <text variable="collection-title" prefix=": "/>
-            <text macro="locators"/>
-            <!--Dados complementares "pagina, volume"-->
-            <text macro="event"/>
-            <!--Nome do evento, conferencia-->
-            <text macro="publisher" prefix=". " suffix=". "/>
-            <!--Local, data, etc-->
-            <text macro="access" suffix="."/>
-            <!--URL, data do acesso-->
-          </group>
-        </else-if>
-        <!--Texto para Discussao (Verbete de Dicionario)-->
-        <else-if type="entry-dictionary">
-          <group>
-            <text macro="author" suffix=". "/>
-            <!--Autor-->
-            <text macro="title"/>
-            <!--Titulo-->
-            <text macro="container-contributors"/>
-            <!--Nomes de editores-->
-            <text macro="secondary-contributors"/>
-            <text macro="container-title"/>
-            <!--Titulo da publicacao-->
-            <text variable="collection-title" prefix=": " suffix=". "/>
-            <text macro="locators"/>
-            <!--Dados complementares "pagina, volume"-->
-            <text macro="event"/>
-            <!--Nome do evento, conferencia-->
-            <text macro="publisher" prefix=". " suffix=". "/>
-            <!--Local, data, etc-->
-            <text macro="collection-title" prefix="(Texto para discussao, n. " suffix=")."/>
-            <text macro="access"/>
-            <!--URL, data do acesso-->
-          </group>
-        </else-if>
-        <!--Nota Tecnica (Verbete de Enciclopedia)-->
-        <else-if type="entry-encyclopedia">
-          <group>
-            <text macro="author" suffix=". "/>
-            <!--Autor-->
-            <text macro="title"/>
-            <!--Titulo-->
-            <text variable="publisher-place" prefix=". " suffix=": "/>
-            <!--Local-->
-            <text variable="publisher" suffix=", "/>
-            <!--Editor-->
-            <text macro="issued" prefix=", " suffix=". (Nota técnica)."/>
-            <!--Data-->
-          </group>
-        </else-if>
-        <else-if type="paper-conference">
-          <text macro="author" suffix=". "/>
-          <!--Autor-->
-          <text macro="title" suffix=". "/>
-          <!--Titulo-->
-          <text macro="container-contributors"/>
-          <!--Nomes de editore-->
-          <text macro="secondary-contributors"/>
-          <text macro="container-title"/>
-          <!--Titulo da publicacao-->
-          <text variable="collection-title" prefix=": " suffix="."/>
-          <text macro="locators"/>
-          <!--Dados complementares "pagina, volume"-->
-          <group delimiter=". " prefix=". " suffix=". ">
-            <text macro="event"/>
-            <!--Nome do evento, conferencia-->
-          </group>
-          <text variable="publisher-place" suffix=": "/>
-          <!--Local-->
-          <text variable="publisher" suffix=", "/>
-          <!--Editor-->
-          <text macro="issued"/>
-          <!--Data-->
-          <text macro="access"/>
-          <!--URL, data do acesso-->
-        </else-if>
-        <else>
-          <text macro="author" suffix=". "/>
-          <!--Autor-->
-          <text macro="title"/>
-          <!--Titulo-->
-          <text macro="container-contributors"/>
-          <!--Nomes de editore-->
-          <text macro="secondary-contributors"/>
-          <text macro="container-title"/>
-          <!--Titulo da publicacao-->
-          <text variable="collection-title" prefix=": " suffix="."/>
-          <text macro="locators"/>
-          <!--Dados complementares "pagina, volume"-->
-          <group delimiter=". " prefix=". " suffix=". ">
-            <text macro="event"/>
-            <!--Nome do evento, conferencia-->
-          </group>
-          <text variable="publisher-place"/>
-          <!--Local-->
-          <text variable="publisher" suffix=", "/>
-          <!--Editor-->
-          <text macro="issued" prefix=", " suffix=". "/>
-          <!--Data-->
-          <text macro="access"/>
-          <!--URL, data do acesso-->
-        </else>
-      </choose>
-    </layout>
-  </bibliography>
+	<macro name="translator">
+		<text value="Tradução "/>
+		<names variable="translator" delimiter=", ">
+			<name delimiter="; " sort-separator=" " delimiter-precedes-last="always">
+				<name-part name="given" text-case="capitalize-first"/>
+				<name-part name="family" text-case="capitalize-first"/>
+			</name>
+			<et-al/>
+		</names>
+	</macro>
+	<!--A macro 'author' é responsável por mostrar os nomes dos autores na bibliografia, serão no formato SOBRENOME, INICIAIS PRENOMES, tendo as inicias separadas por ponto. Quando houver mais de três autores, somente o primeiro sera mostrado e no lugar dos outros aparecerá a expressão 'et. al.'. Na regra da ABNT essa expressão deve aparecer em fonte normal.-->
+	<macro name="author">
+		<names variable="author">
+			<name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; " delimiter-precedes-last="always">
+				<name-part name="family" text-case="uppercase"/>
+				<name-part name="given" text-case="uppercase"/>
+			</name>
+			<et-al/>
+			<label form="short" prefix=" (" suffix=".)" text-case="uppercase"/>
+			<substitute>
+				<names variable="editor"/>
+				<names variable="translator"/>
+				<text macro="title"/>
+			</substitute>
+		</names>
+	</macro>
+	<!--A macro 'author-short' é responsável por mostrar os nomes dos autores na citação (no meio do texto). Nela aparecerá apenas o último nome do autor. Na regra da ABNT o sobrenome deve aparecer com todas as letras em caixa alta.-->
+	<macro name="author-short">
+		<names variable="author">
+			<!--
+			<name form="short" name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; " delimiter-precedes-last="always">
+			-->
+			<name form="short" delimiter="; ">
+				<name-part name="family" text-case="uppercase"/>
+				<name-part name="given" text-case="capitalize-all" prefix=", "/>
+			</name>
+			<et-al font-style="italic"/>
+			<substitute>
+				<names variable="editor"/>
+				<names variable="translator"/>
+				<choose>
+				<if type="book">
+					<text variable="title" text-case="uppercase"/>
+				</if>
+				<else>
+					<text variable="title" form="short" quotes="false" text-case="uppercase"/> <!--Cai aqui quando é uma norma, coloca de preferência o título curto-->
+				</else>
+				</choose>
+			</substitute>
+		</names>
+	</macro>
+	<!--A macro 'access' é utilizada em arquivos de páginas da web. Ela é responsável por mostrar a URL do site pesquisado e a data do acesso-->
+	<macro name="access">
+	<text variable="URL" prefix="Disponível em: &lt;" suffix="&gt;."/>
+	<date variable="accessed" prefix=" Acesso em: ">
+		<date-part name="day" suffix=" "/>
+		<date-part name="month" form="short" suffix=" " text-case="lowercase"/>
+		<date-part name="year" suffix="."/>
+	</date>
+	</macro>
+	<!--A macro 'title' é responsável por mostrar o título principal do arquivo. Em todos os tipos ele aparecera em negrito logo apos os nomes dos autores, exceto em arquivos do tipo 'artigo de jornal, artigo de revista, artigo de periódico', nesses arquivos eles irão aparecer em fonte normal.-->
+	<macro name="title">
+		<choose>
+		<if type="chapter bill" match="any">
+			<text variable="title"/>
+		</if>
+		<else-if type="book thesis" match="any">
+			<text variable="title" font-weight="bold"/>
+		</else-if>
+		<!-- Adicionado "paper-conference" abaixo, pois quando aparecer a expressão "Anais..." em negrito, o título não permanece em negrito-->
+		<else-if type="paper-conference article-newspaper article-magazine article-journal" match="any">
+			<text variable="title"/>
+		</else-if>
+		<else>
+			<text variable="title" font-weight="bold"/>
+		</else>
+		</choose>
+	</macro>
+	<!-- Título dos Anais-->
+	<macro name="container-title">
+		<choose>
+		<if type="paper-conference" match="any">
+			<!--<text variable="container-title" suffix=". "/>-->
+			<text value="Anais" font-weight="bold"/>
+			<text value="..."/>
+		</if>
+		<else>
+			<text variable="container-title" font-weight="bold"/>
+		</else>
+		</choose>
+	</macro>
+	<!--A macro 'publisher' é responsável por mostrar o nome da editora responsável pela publicação-->
+	<macro name="publisher">
+		<choose>
+		<if type="thesis"> <!--Caso seja tese de doutorado, dissertação de mestrado, monografia de especialização ou trabalho de graduação-->
+			<group prefix=" " suffix="."> <!--Não é tratada corretamente a excessão de não ter o nome do lugar e data da publicação-->
+				<text variable="genre" suffix=" - "/> <!--Tipo do trabalho-->
+				<choose>
+				<if match="any" variable="publisher">
+					<text variable="publisher" suffix="."/>
+				</if>
+				<else>
+					<text value="[s.n.]" prefix=" " suffix="."/>
+				</else>
+				</choose>
+			</group>
+			<choose>
+			<if match="any" variable="publisher-place">
+				<text variable="publisher-place" prefix=" " suffix=","/>
+			</if>
+			<else>
+				<text value="[S.l.]" prefix=" " suffix="."/>
+			</else>
+			</choose>
+			<text macro="issued"/>
+		</if>
+		<else> <!-- Todos os demais tipos de publicação-->
+			<choose>
+			<if match="any" variable="publisher-place publisher">
+				<choose>
+				<if variable="publisher-place">
+					<text variable="publisher-place" prefix=" " suffix=": "/>
+				</if>
+				<else-if type="entry-encyclopedia">
+				</else-if>
+				<else>
+					<text value="[S.l.]" prefix=" " suffix="."/>
+				</else>
+				</choose>
+				<choose>
+				<if variable="publisher">
+					<text variable="publisher" prefix=" " suffix=", "/>
+					<text macro="issued"/>
+				</if>
+				<else>
+					<text value="[s.n.]" prefix=" " suffix="."/>
+				</else>
+				</choose>
+			</if>
+			<else>
+				<text value="[S.l: s.n.]" prefix=" " suffix="."/>
+			</else>
+			</choose>
+		</else>
+		</choose>
+	</macro>
+	<!--A macro 'event' será utilizada em arquivos do tipo Evento/conferência. Ela é responsável por mostrar o nome da conferência, que terá formatação em caixa alta. Utiliza-se antes do nome da conferência a expressão "In". Segundo a regra da ABNT ela deve ser em fonte normal.-->
+	<macro name="event">
+		<choose>
+		<if variable="event">
+		<choose>
+			<if variable="genre" match="none">
+				<text term="in" text-case="capitalize-first" suffix=": "/>
+				<text variable="event" text-case="uppercase"/>
+			</if>
+			<else>
+			<group delimiter=" ">
+				<text variable="genre" text-case="capitalize-first"/>
+				<text term="presented at"/>
+				<text variable="event"/>
+			</group>
+			</else>
+		</choose>
+		</if>
+		</choose>
+	</macro>
+	<!--A macro 'issued' é utilizada quando devemos mostrar a data completa exemplo: 03 mar. 2011.-->
+	<macro name="issued">
+		<choose>
+		<if variable="issued" match="any">
+		<group>
+			<choose>
+			<if type="book chapter" match="none">
+				<date variable="issued">
+					<date-part name="day" prefix=" "/>
+					<date-part name="month" form="short" prefix=" " suffix="." strip-periods="true"/>
+				</date>
+			</if>
+			</choose>
+				<date variable="issued">
+				<date-part name="year" prefix=" " suffix="."/>
+			</date>
+		</group>
+		</if>
+		<else>
+			<text value="[S.d.]"  prefix=" " suffix="."/>
+		</else>
+		</choose>
+	</macro>
+	<!--A macro 'issued' é utilizada quando desejamos que apareça apenas o ano-->
+	<macro name="issued-year">
+		<choose>
+		<if variable="issued" match="any">
+			<date variable="issued">
+				<date-part name="year"/>
+			</date>
+		</if>
+		<else>
+		<text value="[S.d.]" prefix=" " suffix=""/>
+		</else>
+		</choose>
+	</macro>
+	<!--A macro 'edition' é responsável por mostrar o número da edição.-->
+	<macro name="edition">
+		<choose>
+		<!--Se for capitulo de livro aparecera somente o número-->
+		<if type="book chapter" match="any">
+			<choose>
+			<if is-numeric="edition">
+			<group delimiter=" ">
+				<number variable="edition" form="numeric" suffix="."/>
+				<text term="edition" form="short" suffix="."/>
+			</group>
+			</if>
+			<else>
+			<!--Se for outro tipo de documento aparerá o número e depois a descrição "ed."-->
+			<text variable="edition" suffix=" ed."/>
+			</else>
+			</choose>
+		</if>
+		</choose>
+	</macro>
+	<!--A macro 'locators'tem como função mostrar os dados complementares do arquivo (páginas, seção, volume, etc)-->
+	<macro name="locators">
+		<choose>
+		<!--Se for projeto de lei mostrara o dia, mês "forma curta", ano, seção "Sec." e página "p."-->
+		<if type="bill">
+		<group prefix=". " suffix="" delimiter=", ">
+			<date variable="issued">
+				<date-part name="day"/>
+				<date-part prefix=" " name="month" form="short"/>
+				<date-part prefix=" " name="year"/>
+			</date>
+			<text variable="section" prefix="Sec. "/>
+			<text variable="page" prefix="p. " suffix="."/>
+		</group>
+		</if>
+		<!--Se for artigos de jornal, revista, etc. Aparecera o volume "v.", edição "n." e a página do artigo "p."-->
+		<else-if match="any" type="article-journal article-magazine article-newspaper">
+		<group delimiter=", ">
+			<group delimiter=", ">
+			<text variable="volume" prefix="v. "/>
+			<text variable="issue" prefix="n. " suffix=""/>
+			</group>
+			<text variable="page" prefix="p. "/>
+		</group>
+		</else-if>
+		<!--Se for capitulo de livro aparecerá o volume "v." e a página "p."-->
+		<else-if match="any" type="book chapter">
+		<group delimiter=", ">
+			<group>
+			<text variable="volume" prefix="v. "/>
+			<text variable="page" prefix="p. "/>
+			</group>
+		</group>
+		</else-if>
+		</choose>
+	</macro>
+	<!--Resumo-->
+	<macro name="abstract">
+	<text variable="abstract"/>
+	</macro>
+	<!--Mostra a ISBN-->
+	<macro name="ISBN">
+	<group>
+		<text variable="ISBN" prefix="ISBN "/>
+	</group>
+	</macro>
+	<macro name="collection-title">
+		<text variable="collection-title"/>
+		<text variable="collection-number" prefix=" "/>
+	</macro>
+	<!--Citação-->
+	<!--et al. aparece a partir de 04 autores-->
+	<!--Quando houver coincidência de sobrenomes de autores, acrescentam-se as iniciais de seus prenomes.-->
+	<!--Quando houve coincidência de todos sobrenomes usar o primeiro nome-->
+	<!--Quando as citações de mesmo autor puderem ser diferenciadas apenas pelo ano, colapsar os nomes-->
+	<citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name" disambiguate-add-year-suffix="false" year-suffix-delimiter="; ">
+	<!--<citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-names="true" disambiguate-add-givenname="all-names" givenname-disambiguation-rule="primary-name" disambiguate-add-year-suffix="false" collapse="year" year-suffix-delimiter="; ">-->
+	<!-- Não aceita ainda citações conjuntas do mesmo sobrenome de autor no mesmo ano-->
+	<sort>
+		<key macro="author"/> <!--Puxa o autor primeiro-->
+		<key variable="issued"/> <!--Depois o ano-->
+	</sort>
+	<layout prefix="(" suffix=")" delimiter="; ">
+		<!--Entre parenteses separando os autores com ponto-e-virgula-->
+		<text macro="author-short"/> <!--Separando os autores das datas usando virgula-->
+		<text macro="issued-year" prefix=", "/>
+		<text macro="citation-locator" prefix=", "/>
+	</layout>
+	</citation>
+	<!--Bibliografia-->
+	<!--et al. não aparece, pois deve aparecer todos os autores-->
+	<bibliography hanging-indent="false" entry-spacing="12" subsequent-author-substitute="______" subsequent-author-substitute-rule="complete-all">
+	<sort>
+		<key macro="author"/> <!--Puxa o autor primeiro-->
+		<key macro="title"/> <!--O título é segunda classe para ordenar as referências-->
+		<key variable="issued"/> <!--Depois o ano-->
+	</sort>
+	<layout>
+		<choose>
+		<!--Projeto de lei-->
+		<if type="bill">
+			<group>
+				<text macro="author" suffix="."/> <!--Autor-->
+				<text variable="number" prefix=" " suffix="."/> <!--número da lei-->
+				<text macro="title" prefix=" " suffix="."/> <!--Título-->
+				<text variable="references" font-weight="bold"/> <!--Historico em negrito-->
+				<text variable="note"/> <!--Campo 'extra' caso queira colocar alguma observação-->
+				<text macro="locators" prefix=" " suffix="."/> <!--Dados complementares "seção, página"-->
+			</group>
+		</if>
+		<!--Mapa-->
+		<else-if type="map">
+			<group>
+				<text macro="author" suffix="."/> <!--autor-->
+				<text macro="title" prefix=" " suffix=","/> <!--Título-->
+				<text macro="issued" prefix=" " suffix="."/> <!--data-->
+				<text variable="note" prefix=" " suffix="."/> <!--Campo 'extra' caso queira colocar alguma observação-->
+			</group>
+		</else-if>
+		<!--Livro-->
+		<else-if type="book">
+			<group>
+				<text macro="author" suffix="."/> <!--autor-->
+				<text macro="title" prefix=" " suffix="."/> <!--Título-->
+				<text macro="translator" prefix=" " suffix="."/> <!--Tradução-->
+				<text macro="edition" prefix=" " suffix="."/> <!--Edição-->
+				<text macro="publisher" prefix=" " suffix="."/> <!--Local, data, etc-->
+				<text macro="locators"/> <!--Dados complementares "página, volume"-->
+				<text macro="ISBN" prefix=" " suffix="."/>
+			</group>
+		</else-if>
+		<!--Conferência-->
+		<else-if type="chapter">
+			<group>
+				<text macro="author" suffix="."/> <!--Autor-->
+				<text macro="title" prefix=" " suffix="."/> <!--Título-->
+				<text macro="secondary-contributors" prefix=" " suffix="."/>
+				<text term="in" text-case="capitalize-first" prefix=" " suffix=":"/> <!--In:-->
+				<text macro="container-contributors" prefix=" " suffix="."/> <!--Nomes de editores-->
+				<text macro="container-title" prefix=" " suffix="."/> <!--Título da conferência-->
+				<text variable="collection-title" prefix=" " suffix="."/>
+				<text macro="translator" prefix=" " suffix="."/> <!--Tradução-->
+				<text macro="edition" prefix=" " suffix="."/> <!--Edição-->
+				<group>
+					<text macro="publisher" prefix=" " suffix="."/> <!--Local, data, etc-->
+					<text macro="locators" prefix=" " suffix="."/> <!--Dados complementares "página, volume"-->
+				</group>
+			</group>
+		</else-if>
+		<!--Artigo de revista, jornal, etc-->
+		<else-if type="article-newspaper article-magazine article-journal" match="any">
+			<group>
+				<text macro="author" suffix="."/> <!--Autor-->
+				<text macro="title" prefix=" " suffix="."/> <!--Título do artigo-->
+				<text macro="container-title" prefix=" " suffix=","/> <!--Título da publicação-->
+				<text variable="collection-title" prefix=" " suffix="."/> <!--Título da serie-->
+				<text macro="edition" prefix=" " suffix=","/> <!--Edição-->
+				<text macro="locators" prefix=" " suffix=","/> <!--Dados complementares "página, volume"-->
+				<text macro="issued" prefix=" " suffix="."/> <!--Data-->
+			</group>
+		</else-if>
+		<!--Tese-->
+		<else-if type="thesis">
+			<group>
+				<text macro="author" suffix="."/> <!--Autor-->
+				<text macro="title" prefix=" " suffix="."/> <!--Título-->
+				<text macro="edition" prefix=" " suffix="."/> <!--Edição-->
+				<text macro="publisher" prefix=" " suffix="."/> <!--Local, data, etc-->
+			</group>
+		</else-if>
+		<!-- Não há norma ABNT para manuscritos -->
+		<else-if type="manuscript">
+			<group>
+				<text macro="author" suffix="."/> <!--Autor-->
+				<text macro="title" prefix=" " suffix="."/> <!--Título-->
+				<text macro="edition" prefix=" " suffix="."/> <!--Edição-->
+				<text macro="place" prefix=" " suffix=","/> <!--Lugar-->
+				<text macro="issued" prefix=" " suffix="."/> <!--Data-->
+				<text macro="access" prefix=" " suffix="."/> <!--URL, data do acesso-->
+				<text macro="archive" prefix=" " suffix="."/> <!--Arquive-->
+			</group>
+		</else-if>
+		<!--Página da WEB-->
+		<else-if type="webpage">
+			<group>
+				<text macro="author" suffix="."/> <!--Autor-->
+				<text macro="title" prefix=" " suffix="."/> <!--Título-->
+				<text macro="genre" prefix=" " suffix="."/>
+				<text macro="access" prefix=" " suffix="."/> <!--URL, data do acesso-->
+			</group>
+		</else-if>
+		<!--Relatório-->
+		<else-if type="report">
+			<group>
+				<text macro="author" suffix="."/> <!--Autor-->
+				<text macro="title" prefix=" " suffix="."/> <!--Título-->
+				<text macro="container-contributors" prefix=" " suffix="."/> <!--Nomes de editores-->
+				<text macro="secondary-contributors" prefix=" " suffix="."/>
+				<text macro="container-title" prefix=" "/> <!--Título da publicação-->
+				<text variable="collection-title" prefix=": " suffix=""/>
+				<text macro="locators"/> <!--Dados complementares "página, volume"-->
+				<text macro="event" prefix=" " suffix="."/> <!--Nome do evento, conferência-->
+				<text macro="publisher" prefix=" " suffix="."/> <!--Local, data, etc-->
+				<text macro="access" prefix=" " suffix="."/> <!--URL, data do acesso-->
+			</group>
+		</else-if>
+		<!--Texto para Discussão (Verbete de Dicionario)-->
+		<else-if type="entry-dictionary">
+			<group>
+				<text macro="author" suffix="."/> <!--Autor-->
+				<text macro="title" prefix=" " suffix="."/> <!--Título-->
+				<text macro="container-contributors" prefix=" " suffix="."/> <!--Nomes de editores-->
+				<text macro="secondary-contributors" prefix=" " suffix="."/>
+				<text macro="container-title" prefix=" "/> <!--Título da publicação-->
+				<text variable="collection-title" prefix=": " suffix=". "/>
+				<text macro="locators" prefix=" " suffix="."/> <!--Dados complementares "página, volume"-->
+				<text macro="event" prefix=" " suffix="."/> <!--Nome do evento, conferência-->
+				<text macro="publisher" prefix=" " suffix="."/> <!--Local, data, etc-->
+				<text macro="collection-title" prefix=" (Texto para discussão, n. " suffix=")."/>
+				<text macro="access" prefix=" " suffix="."/> <!--URL, data do acesso-->
+			</group>
+		</else-if>
+		<!--Nota Técnica (Verbete de Enciclopédia)-->
+		<else-if type="entry-encyclopedia">
+			<group>
+				<text macro="author" suffix="."/> <!--Autor-->
+				<text macro="title" prefix=" " suffix="."/> <!--Título-->
+				<text variable="publisher-place" prefix=" "/> <!--Local-->
+				<text variable="publisher" prefix=": " suffix=", "/> <!--Editor-->
+				<text macro="issued" suffix=". (Nota técnica)."/> <!--Data-->
+			</group>
+		</else-if>
+		<else-if type="paper-conference">
+			<text macro="author" suffix="."/> <!--Autor-->
+			<text macro="title" prefix=" " suffix="."/> <!--Título-->
+			<text macro="container-contributors" prefix=" " suffix="."/> <!--Nomes de editore-->
+			<text macro="secondary-contributors" prefix=" " suffix="."/>
+			<group delimiter=". " prefix=" " suffix=".">
+				<text macro="event"/> <!--Nome do evento, conferência-->
+			</group>
+			<text macro="container-title" prefix=" "/>
+			<text variable="publisher-place" prefix=" "/> <!--Local-->
+			<!--Título da publicação-->
+			<text variable="collection-title" prefix=": " suffix="."/>
+			<text macro="locators" suffix="."/> <!--Dados complementares "página, volume"-->
+			<text variable="publisher" prefix=": " suffix=","/> <!--Editor-->
+			<text macro="issued" prefix=" " suffix="."/> <!--Data-->
+			<text macro="access" prefix=" " suffix="."/> <!--URL, data do acesso-->
+		</else-if>
+		<else>
+			<text macro="author" suffix="."/> <!--Autor-->
+			<text macro="title" prefix=" " suffix="."/> <!--Título-->
+			<text macro="container-contributors" prefix=" " suffix="."/> <!--Nomes de editore-->
+			<text macro="secondary-contributors" prefix=" " suffix="."/>
+			<text macro="container-title" prefix=" "/> <!--Título da publicação-->
+			<text variable="collection-title" prefix=": " suffix="."/>
+			<text macro="locators" prefix=" " suffix="."/> <!--Dados complementares "página, volume"-->
+			<group delimiter=". " prefix=". " suffix=". ">
+				<text macro="event"/> <!--Nome do evento, conferência-->
+			</group>
+			<text variable="publisher-place" prefix=" " suffix="."/> <!--Local-->
+			<text variable="publisher" prefix=" "/> <!--Editor-->
+			<text macro="issued" prefix=", " suffix=". "/> <!--Data-->
+			<text macro="access" prefix=" " suffix="."/> <!--URL, data do acesso-->
+		</else>
+		</choose>
+	</layout>
+	</bibliography>
+	<!--As macros abaixo não foram utilizadas na bibliografia-->
+	<macro name="citation-locator">
+	<group>
+		<label variable="locator" form="short"/>
+		<text variable="locator" prefix=" "/>
+	</group>
+	</macro>
+	<macro name="genre">
+	<text variable="genre"/>
+	</macro>
+	<macro name="place">
+		<choose>
+		<if match="any" variable="publisher-place">
+			<text variable="publisher-place"/>
+		</if>
+		</choose>
+	</macro>
+	<macro name="archive">
+	<group>
+		<text variable="archive" prefix=" "/>
+	</group>
+	</macro>
 </style>


### PR DESCRIPTION
Fixed punctuation (suffix) errors in titles, site names, and dates in references.
The expression "et al." should be in italics because it is in another language.
The spacing between each entry of references must be 1 line ("12 pt" using standard letters).
The month "May" is not followed by a "." suffix.
When using the expression "Anais..." (which appears in bold), the title does not remain in bold.
All authors must appear in the references, with no limit on quantity.
When more than one citation occurs at the same time, they must be separated by ";".
When citations by the same author can be distinguished only by year, collapse the names.